### PR TITLE
The /api/generate endpoint was failing with a 413 'Payload Too Large'…

### DIFF
--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -83,3 +83,11 @@ export default async function handler(
     res.status(500).json({ text: `Failed to process image: ${errorMessage}`, image: null });
   }
 }
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb',
+    },
+  },
+};


### PR DESCRIPTION
… error when uploading large images. This was caused by the default Next.js body parser limit of 1mb.

This change increases the body parser size limit to 10mb for the /api/generate route specifically, allowing larger images to be processed without error.